### PR TITLE
v0.1.1 - filter, orEmpty, removeEmpty, optional changes

### DIFF
--- a/honeycomb.nim
+++ b/honeycomb.nim
@@ -440,7 +440,7 @@ func `|`*[T](a, b: Parser[T]): Parser[T] =
     fail(input, result1.expected & result2.expected, input)
 
 func `&`*[T](a, b: Parser[seq[T]]): Parser[seq[T]] =
-  ## Expects each parser in sequence from left to right, creating a `seq` of their results.
+  ## Expects each parser in sequence from left to right, creating a `seq` of their results. If one or both of the parsers already results in a `seq` of the other's type, the two `seq`s will be merged.
   ## 
   ## See also:
   ## - [chain](#chain.t,Parser[T],Parser[T],varargs[Parser[T]]) - textual equivalent to this operator
@@ -509,6 +509,8 @@ func `>>`*[T](a: Parser, b: Parser[T]): Parser[T] =
 
 func `*`*[T](a: Parser[T], n: int): Parser[seq[T]] =
   ## Expects the parser a given number of times, returning a `seq` of the matches. Also supports slices as ranges of valid amounts (see [*](#*.t,Parser[T],Slice[int])).
+  ##
+  ## Note that this will succeed early if the given parser succeeds but doesn't consume any input, in order to prevent infinite loops caused by parsers like [nop](#nop) or [atMost](#atMost.t,Parser[T],int). This means it may not work correctly on parsers with non-deterministic behavior or which use/modify external state; this is intentionally undefined behavior.
   ##
   ## See also:
   ## - [times](#times.t,Parser,auto) - textual equivalent to this operator

--- a/honeycomb.nim
+++ b/honeycomb.nim
@@ -1,4 +1,4 @@
-# Honeycomb v0.1.0
+# Honeycomb v0.1.1
 # Created by KatrinaKitten
 
 ## Honeycomb is a parser combinator library written in pure Nim. It's designed to be simple, straightforward, and easy to expand, while relying on zero dependencies from outside of Nim's standard library.

--- a/honeycomb.nimble
+++ b/honeycomb.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.0"
+version       = "0.1.1"
 author        = "Katrina Scialdone"
 description   = "A dead simple, no-nonsense parser combinator library written in pure Nim."
 license       = "MPL-2.0"

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -706,3 +706,15 @@ suite "integration examples":
     check result2.error     == "[1:3] Expected valid expression"
     check result2.tail      == "+ "
     check result2.fromInput == "1 + "
+
+suite "reported issues":
+
+  test "#3: atLeast and atMost together makes the parser hang":
+    let
+      parser = digit.atMost(3).atLeast(4)
+      result = parser.parse("255314")
+
+    check result.kind      == success
+    check result.value     == @[@['2','5','5'], @['3','1','4'], @[], @[]]
+    check result.tail      == ""
+    check result.fromInput == "255314"

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -743,10 +743,10 @@ suite "reported issues":
 
   test "#3: atLeast and atMost together makes the parser hang":
     let
-      parser = digit.atMost(3).atLeast(4)
+      parser = digit.atMost(3).atLeast(4).removeEmpty
       result = parser.parse("255314")
 
     check result.kind      == success
-    check result.value     == @[@['2','5','5'], @['3','1','4'], @[], @[]]
+    check result.value     == @[@['2','5','5'], @['3','1','4']]
     check result.tail      == ""
     check result.fromInput == "255314"

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -295,6 +295,22 @@ suite "general combinators":
     check result2.tail      == "Hello, world!"
     check result2.fromInput == "Hello, world!"
 
+  test "filter":
+    let
+      parser  = digit.asString.atLeast(1).mapEach(parseInt).filter(x => x >= 5)
+      result1 = parser.parse("0918273654")
+      result2 = parser.parse("Hello, world!")
+
+    check result1.kind      == success
+    check result1.value     == @[9,8,7,6,5]
+    check result1.tail      == ""
+    check result1.fromInput == "0918273654"
+
+    check result2.kind      == failure
+    check result2.error     == "[1:1] Expected character from 0..9"
+    check result2.tail      == "Hello, world!"
+    check result2.fromInput == "Hello, world!"
+
   test "oneOf":
     let parsers = [
       s("Hello") | s("Greetings"),
@@ -539,6 +555,22 @@ suite "general combinators":
       result2 = parser.parse("")
 
     check result1.kind      == success
+    check result1.value     == "Hello"
+    check result1.tail      == ""
+    check result1.fromInput == "Hello"
+
+    check result2.kind      == success
+    check result2.value     == ""
+    check result2.tail      == ""
+    check result2.fromInput == ""
+
+  test "orEmpty":
+    let 
+      parser  = s("Hello").orEmpty()
+      result1 = parser.parse("Hello")
+      result2 = parser.parse("")
+
+    check result1.kind      == success
     check result1.value     == @["Hello"]
     check result1.tail      == ""
     check result1.fromInput == "Hello"
@@ -667,7 +699,7 @@ suite "integration examples":
     var expression = fwdcl[float]()
     let
       padding = regex(r"\s*")
-      number  = (digit.atLeast(1) & (c('.') & digit.atLeast(1)).optional).flatten.join.map(parseFloat)
+      number  = (digit.atLeast(1) & (c('.') & digit.atLeast(1)).optional).join.map(parseFloat)
       parens  = c('(') >> padding >> expression << padding << c(')')
       operand = number | parens
 


### PR DESCRIPTION
This update adds a few functions for dealing more easily with `Parser[seq]`s, makes a breaking change to the behavior of `optional`, and fixes #3 by expecting each attempt at a parse repeated with `*` to modify the tail.

Additions:
- `filter` - Filter a `Parser[seq]`'s results by a given predicate
- `orEmpty` - Expect a parser optionally, wrapping it in `seq` and returning an empty `seq` if it doesn't match
- `removeEmpty` - Remove empty `seq`s from a `Parser[seq[seq]]`

Changes:
- **[BREAKING]** `optional` now returns the default value of `T` instead of an empty `seq[T]` if it doesn't match - for the previous behavior, use `orEmpty` instead
- `*(int)` now executes lazily instead of generating a large internal structure for high values of `n`
- `*(int)` now expects each attempt to modify the tail to prevent infinite success loops (the effect of this change on non-deterministic parsers is intentional undefined behavior)
- `*(Slice)` is now a template implemented in terms of `*(int)`